### PR TITLE
feat: implement posted date scrapper

### DIFF
--- a/src/JobApp.re
+++ b/src/JobApp.re
@@ -2,18 +2,21 @@ type state = {
   url: string,
   company: string,
   position: string,
+  postedDate: string,
 };
 
 type action =
   | UpdateUrl(string)
   | UpdateCompany(string)
-  | UpdatePosition(string);
+  | UpdatePosition(string)
+  | UpdatePostedDate(string);
 
 let reducer = (action, _state) =>
   switch (action) {
   | UpdateUrl(value) => ReasonReact.Update({..._state, url: value})
   | UpdateCompany(value) => ReasonReact.Update({..._state, company: value})
   | UpdatePosition(value) => ReasonReact.Update({..._state, position: value})
+  | UpdatePostedDate(value) => ReasonReact.Update({..._state, postedDate: value})
   };
 
 let component = ReasonReact.reducerComponent("JobApp");
@@ -21,12 +24,13 @@ let component = ReasonReact.reducerComponent("JobApp");
 let make = (~submitHandler, ~signOutHandler, _children) => {
   ...component, /* spread the template's other defaults into here  */
   reducer,
-  initialState: () => {url: "", company: "", position: ""},
+  initialState: () => {url: "", company: "", position: "", postedDate: ""},
   render: self => {
     /** Event handlers which function as sort of dispatchers */
     let changeUrl = x => self.send(UpdateUrl(x));
     let changeCompany = x => self.send(UpdateCompany(x));
     let changePosition = x => self.send(UpdatePosition(x));
+    let changePostedDate = x => self.send(UpdatePostedDate(x));
     <div>
       <form>
         <ScrapingInput
@@ -61,7 +65,16 @@ let make = (~submitHandler, ~signOutHandler, _children) => {
         />
         <div className="form-horizontal-separator">
           <label> (ReasonReact.stringToElement("Date posted")) </label>
-          <input _type="date" name="dateposted" />
+          <ScrapingInput
+            script=ScrapingFunctions.scriptBody
+            typeValue="date"
+            validationFn=ScrapingFunctions.validateDate
+            processFn=ScrapingFunctions.extractPostedDateProcess
+            reducerFn=changePostedDate
+            name="postedDate"
+            placeholder=""
+            value=self.state.postedDate
+          />
         </div>
         <div className="form-horizontal-separator">
           <label> (ReasonReact.stringToElement("Deadline")) </label>

--- a/src/ScrapingFunctions.re
+++ b/src/ScrapingFunctions.re
@@ -58,11 +58,11 @@ let daysAgoDate = (x: string) => {
 let extractPostedDateProcess = x: string => {
   let stringBody = x |> Js.String.make;
 
-  Js.String.match(postedDateRegex, stringBody)
-    |> result => switch (result) {
-      | None => ""
-      | Some(match) => daysAgoDate(match[1])
-    };
+  let result = Js.String.match(postedDateRegex, stringBody);
+  switch (result) {
+  | None => ""
+  | Some(match) => daysAgoDate(match[1])
+  };
 };
 
 let checkValidUrl = x => {

--- a/src/ScrapingFunctions.re
+++ b/src/ScrapingFunctions.re
@@ -1,5 +1,6 @@
 /** For checking if a URL is valid */
 let urlRegex = [%bs.re "/^((?:https?:\/\/)?[^./]+(?:\.[^./]+)+(?:\/.*)?)$/"];
+let postedDateRegex = [%bs.re "/(\d+)[\s]+days[\s]+ago/gim"];
 
 let scriptUrl = "document.URL";
 
@@ -21,6 +22,9 @@ let scriptPosition = "  var getAreaAndText = el => ({ fontSize: parseFloat(windo
                         .sort((a, b) => b.fontSize - a.fontSize)[0].text";
 
 /** Error checking with comfy optional types  */
+
+let scriptBody = "document.body.innerText";
+
 let validateNonNull = x =>
   switch (x) {
   | None => failwith("Value is null")
@@ -29,9 +33,52 @@ let validateNonNull = x =>
 
 let toStringProcess = x => Js.String.make(x);
 
+let extractPostedDateProcess = x: string => {
+  let stringBody = x |> Js.String.make;
+
+  /* return the date x days ago in the format yyyy-MM-dd */
+  let daysAgoDate(x: string) {
+    let now = Js.Date.make();
+
+    let startIsoOfset = 0;
+    let lengthIsoOfset = 10;
+
+    switch (float_of_int(-1*(int_of_string(x)))) {
+    | delta => Js.Date.setDate(now, delta)
+      |> Js.Date.fromFloat
+      |> Js.Date.toISOString
+      /* unfortunately Js.Date has no method to obtain format yyyy-MMM-dd
+         so we obtain the ISO format and extract the substring of interest */
+      |> Js.String.substrAtMost(~from=startIsoOfset, ~length=lengthIsoOfset);
+    | exception(reason) => Js.log(reason); "";
+    };
+  };
+
+  /* extract the first match from a Regex execution result */
+  let extractFirstMatch = (x: Js.Re.result) => Js.Re.captures(x)[1] |> Js.Nullable.toOption;
+
+  /* Unfortunately could not find single method in the Js.Re API to execute and obtain
+     the matched strings. So it's a 2 step process: exec the Regex, then capture the match */
+  switch (Js.Re.exec(stringBody, postedDateRegex)) {
+  | None => "";
+  | Some(x) =>
+    switch (extractFirstMatch(x)) {
+    | None => "";
+    | Some(x) => daysAgoDate(x);
+    };
+  };
+};
+
 let checkValidUrl = x => {
   let stringUrl = x |> Js.String.make;
   Js.Re.test(stringUrl, urlRegex) ? x : failwith("Invalid URL");
 };
 
+let checkValidPostedDate = x => {
+  let stringUrl = x |> Js.String.make;
+  Js.Re.test(stringUrl, postedDateRegex) ? x : failwith("Unable to find posted date");
+};
+
 let validateUrl = x => x |> validateNonNull |> checkValidUrl;
+
+let validateDate = x => x |> validateNonNull |> checkValidPostedDate;

--- a/src/ScrapingFunctions.re
+++ b/src/ScrapingFunctions.re
@@ -1,6 +1,10 @@
 /** For checking if a URL is valid */
 let urlRegex = [%bs.re "/^((?:https?:\/\/)?[^./]+(?:\.[^./]+)+(?:\/.*)?)$/"];
-let postedDateRegex = [%bs.re "/(\d+)[\s]+days[\s]+ago/gim"];
+
+/** heuristic: the first match for "<num> day[s] ago" in top-bottom order
+    tends to be the posted date of the job application. Subsequent matches
+    are often posted dates for other offers being advertized.*/
+let postedDateRegex = [%bs.re "/(\d+)[\s]+day[s]?[\s]+ago/im"];
 
 let scriptUrl = "document.URL";
 
@@ -21,9 +25,9 @@ let scriptPosition = "  var getAreaAndText = el => ({ fontSize: parseFloat(windo
                         .filter(el => el.text)
                         .sort((a, b) => b.fontSize - a.fontSize)[0].text";
 
-/** Error checking with comfy optional types  */
+/** Error checking with comfy optional types */
 
-let scriptBody = "document.body.innerText";
+let scriptBody = "document.body.innerHTML";
 
 let validateNonNull = x =>
   switch (x) {
@@ -33,34 +37,40 @@ let validateNonNull = x =>
 
 let toStringProcess = x => Js.String.make(x);
 
+/** return the date x days ago in the format yyyy-MM-dd */
+let daysAgoDate = (x: string) => {
+  let now = Js.Date.make();
+
+  /** ISO date format is yyyy-MM-ddThh:mm:ss:msms.nnnZ, we only need the first 10 characters*/
+  let startIsoOfset = 0;
+  let lengthIsoOfset = 10;
+
+  switch (Js.Date.getDate(now) -. float_of_int(int_of_string(x))) {
+  | delta => Js.Date.setDate(now, delta)
+    |> Js.Date.fromFloat
+    |> Js.Date.toISOString
+    /** unfortunately Js.Date has no method to obtain format yyyy-MMM-dd
+       so we obtain the ISO format and extract the substring of interest */
+    |> Js.String.substrAtMost(~from=startIsoOfset, ~length=lengthIsoOfset);
+  | exception (Js.Exn.Error(err)) =>
+      Js.Exn.message(err)
+      |> Js.Option.getWithDefault("Unable to cast string to date")
+      /** trick to be able to log while still returning a string */
+      |> Js.log; "";
+  };
+};
+
 let extractPostedDateProcess = x: string => {
   let stringBody = x |> Js.String.make;
 
-  /* return the date x days ago in the format yyyy-MM-dd */
-  let daysAgoDate(x: string) {
-    let now = Js.Date.make();
-
-    let startIsoOfset = 0;
-    let lengthIsoOfset = 10;
-
-    switch (float_of_int(-1*(int_of_string(x)))) {
-    | delta => Js.Date.setDate(now, delta)
-      |> Js.Date.fromFloat
-      |> Js.Date.toISOString
-      /* unfortunately Js.Date has no method to obtain format yyyy-MMM-dd
-         so we obtain the ISO format and extract the substring of interest */
-      |> Js.String.substrAtMost(~from=startIsoOfset, ~length=lengthIsoOfset);
-    | exception(reason) => Js.log(reason); "";
-    };
-  };
-
-  /* extract the first match from a Regex execution result */
+  /** extract the first match from a Regex execution result */
   let extractFirstMatch = (x: Js.Re.result) => Js.Re.captures(x)[1] |> Js.Nullable.toOption;
 
-  /* Unfortunately could not find single method in the Js.Re API to execute and obtain
+  /** Unfortunately there is no single method in the Js.Re API to execute and obtain
      the matched strings. So it's a 2 step process: exec the Regex, then capture the match */
   switch (Js.Re.exec(stringBody, postedDateRegex)) {
-  | None => "";
+  /** trick to be able to log while still returning a string */
+  | None => Js.log("Unable to find posted date"); "";
   | Some(x) =>
     switch (extractFirstMatch(x)) {
     | None => "";


### PR DESCRIPTION
Following the mechanism set in place by #11, the posted date `ScraperUnit` component has the following props:

- **script**: the text content of the website
- **typeValue**: HTML5 date
- **validationFn**: a fn that checks if we can find in the website a string like this: `<num> day[s] ago`
- **processFn**: a fn that extracts the matched number, obtains the relative date and returns it in HTML5 date format
- **placeholder:** empty to satisfy the `ScraperUnit` props, but unsupported by HTML5 date

Closes #13