### PR TITLE
Feat/16 authentication

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,7 @@
     "default_popup": "popup.html"
   },
   "permissions": [
-    "activeTab",
-    "storage"
+    "activeTab"
   ],
   "web_accessible_resources": [
     "data/*.json"

--- a/src/App.css
+++ b/src/App.css
@@ -11,6 +11,7 @@
 
 body {
   font-family:"Arial", "Helvetica", sans-serif;
+  font-size: var(--baseFontSize);
   margin:0;
   padding:0;
   -webkit-font-smoothing:antialiased;
@@ -161,4 +162,10 @@ select:active {
     linear-gradient(-135deg, transparent 50%, var(--positiveFg) 50%),
     linear-gradient(-225deg, transparent 50%, var(--positiveFg) 50%),
     linear-gradient(var(--positiveFg) 42%, var(--baseBg) 42%);
+}
+
+.error-message {
+  color: #e94b4b;
+  margin: 5px 0;
+  font-weight: 800;
 }

--- a/src/App.re
+++ b/src/App.re
@@ -1,17 +1,13 @@
-type route =
-  | Login
-  | JobApp;
-
-type state = {route};
+type state = {token: string};
 
 type action =
-  | Login
+  | Login(string)
   | Logout;
 
 let reducer = (action, _state) =>
   switch (action) {
-  | Login => ReasonReact.Update({route: JobApp})
-  | Logout => ReasonReact.Update({route: Login})
+  | Login(jwt) => ReasonReact.Update({token: jwt})
+  | Logout => ReasonReact.Update({token: ""})
   };
 
 let component = ReasonReact.reducerComponent("App");
@@ -19,18 +15,17 @@ let component = ReasonReact.reducerComponent("App");
 let make = _children => {
   ...component,
   reducer,
-  initialState: () => {route: Login},
+  initialState: () => {token: ""},
   render: self =>
     <div className="app">
       (
-        switch (self.state.route) {
-        | Login => <Login submitHandler=(_event => self.send(Login)) />
-        | JobApp =>
+        (self.state.token === "") ?
+          <Login updateToken=(token => self.send(Login(token))) />
+          :
           <JobApp
             submitHandler=(_event => self.send(Logout))
             signOutHandler=(_event => self.send(Logout))
           />
-        }
       )
     </div>,
 };

--- a/src/Login.re
+++ b/src/Login.re
@@ -1,12 +1,53 @@
-let component = ReasonReact.statelessComponent("Login");
+type state = {
+  email: string,
+  password: string,
+  error: bool
+};
 
-let make = (~submitHandler, _children) => {
+type action =
+  | UpdateEmail(string)
+  | UpdatePassword(string)
+  | DisplayError
+  | Login;
+
+/** TODO: a binding is better because it offers type-safety */
+let openSignupPage = [%raw {|
+  function(url) {
+    chrome.tabs.create({ url: "http://stackoverflow.com/" });
+  }
+|}];
+
+let component = ReasonReact.reducerComponent("Login");
+
+let make = (~updateToken, _children) => {
   ...component,
-  render: _self =>
+  reducer: (action, state) =>
+    switch (action) {
+    | UpdateEmail(email) => ReasonReact.Update({...state, email: email, error: false})
+    | UpdatePassword(pass) => ReasonReact.Update({...state, password: pass, error: false})
+    | DisplayError => ReasonReact.Update({...state, error: true})
+    | Login =>
+      ReasonReact.UpdateWithSideEffects(
+        {...state, error: false},
+        self => {
+          let _ =
+          Services.authenticate(
+            ~email=state.email,
+            ~password=state.password,
+            ~success=updateToken,
+            ~failure=()=>self.send(DisplayError)
+          )
+          ();
+        }
+      )
+    },
+  initialState: () => {email: "", password: "", error: false},
+  render: self => {
+    let errorMessage = (self.state.error) ? "Invalid credentials" : "";
     <div>
-      <form>
-        <button className="btn submit-btn" onClick=submitHandler tabIndex=1>
-          (ReasonReact.stringToElement("Sign In with Google"))
+      <form onSubmit=openSignupPage>
+        <button className="btn submit-btn" tabIndex=1>
+          (ReasonReact.stringToElement("Sign Up"))
         </button>
       </form>
       <span className="form-vertical-separator">
@@ -14,17 +55,37 @@ let make = (~submitHandler, _children) => {
           (ReasonReact.stringToElement("or"))
         </p>
       </span>
-      <form>
-        <input name="email" placeholder="email" tabIndex=2 />
+      <p className="error-message">(ReasonReact.stringToElement(errorMessage))</p>
+      <form
+        onSubmit={
+          ev => {
+            ReactEventRe.Form.preventDefault(ev);
+            self.send(Login);
+          }
+        }
+      >
+        <input
+          name="email"
+          placeholder="email"
+          value=self.state.email
+          onChange=(ev => UpdateEmail(Services.valueFromEvent(ev)) |> self.send)
+          tabIndex=2
+        />
         <input
           _type="password"
           name="password"
           placeholder="password"
+          value=self.state.password
+          onChange=(ev => UpdatePassword(Services.valueFromEvent(ev)) |> self.send)
           tabIndex=3
         />
-        <button className="btn submit-btn" onClick=submitHandler tabIndex=4>
+        <button
+          className="btn submit-btn"
+          tabIndex=4
+         >
           (ReasonReact.stringToElement("Sign In"))
         </button>
       </form>
-    </div>,
+    </div>
+  }
 };

--- a/src/Login.re
+++ b/src/Login.re
@@ -68,7 +68,7 @@ let make = (~updateToken, _children) => {
           name="email"
           placeholder="email"
           value=self.state.email
-          onChange=(ev => UpdateEmail(Services.valueFromEvent(ev)) |> self.send)
+          onChange=(ev => UpdateEmail(Utilities.valueFromEvent(ev)) |> self.send)
           tabIndex=2
         />
         <input
@@ -76,7 +76,7 @@ let make = (~updateToken, _children) => {
           name="password"
           placeholder="password"
           value=self.state.password
-          onChange=(ev => UpdatePassword(Services.valueFromEvent(ev)) |> self.send)
+          onChange=(ev => UpdatePassword(Utilities.valueFromEvent(ev)) |> self.send)
           tabIndex=3
         />
         <button

--- a/src/Login.re
+++ b/src/Login.re
@@ -47,7 +47,7 @@ let make = (~updateToken, _children) => {
     <div>
       <form onSubmit=openSignupPage>
         <button className="btn submit-btn" tabIndex=1>
-          (ReasonReact.stringToElement("Sign Up"))
+          (ReasonReact.stringToElement("Register"))
         </button>
       </form>
       <span className="form-vertical-separator">

--- a/src/Login.re
+++ b/src/Login.re
@@ -34,7 +34,7 @@ let make = (~updateToken, _children) => {
           Services.authenticate(
             ~email=state.email,
             ~password=state.password,
-            ~success=updateToken,
+            ~callback=updateToken,
             ~failure=()=>self.send(DisplayError)
           )
           ();

--- a/src/ScrapingInput.re
+++ b/src/ScrapingInput.re
@@ -58,6 +58,6 @@ let make =
       value
       /*** Ideally, I would've passed a separate prop such as a "dispatcher" function,
            but honestly for the complexity of our app, I wouldn't bother  */
-      onChange=(evt => Services.valueFromEvent(evt) |> reducerFn)
+      onChange=(evt => Utilities.valueFromEvent(evt) |> reducerFn)
     />,
 };

--- a/src/ScrapingInput.re
+++ b/src/ScrapingInput.re
@@ -1,13 +1,5 @@
 open Chrome.Extensions;
 
-/** Convert value from event to string
-One of the disadvantages from reason is that you have to do this type casting */
-let valueFromEvent = evt => (
-                              evt
-                              |> ReactEventRe.Form.target
-                              |> ReactDOMRe.domElementToObj
-                            )##value;
-
 type scrapingReturn('a) =
   | None
   | Some('a);
@@ -66,6 +58,6 @@ let make =
       value
       /*** Ideally, I would've passed a separate prop such as a "dispatcher" function,
            but honestly for the complexity of our app, I wouldn't bother  */
-      onChange=(evt => valueFromEvent(evt) |> reducerFn)
+      onChange=(evt => Services.valueFromEvent(evt) |> reducerFn)
     />,
 };

--- a/src/Services.re
+++ b/src/Services.re
@@ -66,11 +66,3 @@ let loadCompanyNames = callback =>
        })
   )
   |> ignore;
-
-/** Convert value from event to string
-One of the disadvantages from reason is that you have to do this type casting */
-let valueFromEvent = evt => (
-                              evt
-                              |> ReactEventRe.Form.target
-                              |> ReactDOMRe.domElementToObj
-                            )##value;

--- a/src/Services.re
+++ b/src/Services.re
@@ -1,6 +1,55 @@
+type authResponse = {
+  iat: int,
+  exp: int,
+  token: string
+};
+
 module Decode = {
   let companiesArray = json : array(string) =>
     Json.Decode.(json |> array(string));
+
+  let authResponse = json : authResponse =>
+    Json.Decode.{
+      iat: json |> field("iat", int),
+      exp: json |> field("exp", int),
+      token: json |> field("token", string)
+    };
+};
+
+let authenticate = (~email, ~password, ~success, ~failure, _self) => {
+  let authEndpoint = "https://jobhub-authentication-staging.herokuapp.com/login";
+
+  let payload = Js.Dict.empty();
+  Js.Dict.set(payload, "email", Js.Json.string(email));
+  Js.Dict.set(payload, "password", Js.Json.string(password));
+  let headers = Fetch.HeadersInit.make({"Content-Type": "application/json"});
+  let body = Js.Json.object_(payload)
+    |> Js.Json.stringify
+    |> Fetch.BodyInit.make;
+
+  Js.Promise.(
+    Fetch.fetchWithInit(
+      authEndpoint,
+      Fetch.RequestInit.make(
+        ~method_=Post,
+        ~body=body,
+        ~headers=headers,
+        ()
+      )
+    )
+    |> then_(Fetch.Response.json)
+    |> then_(json =>
+      json
+      |> Decode.authResponse
+      |> resp => success(resp.token)
+      |> resolve
+    )
+    |> catch(err => {
+      Js.log(err);
+      failure();
+      resolve();
+    })
+  )|> ignore
 };
 
 let loadCompanyNames = callback =>
@@ -17,3 +66,11 @@ let loadCompanyNames = callback =>
        })
   )
   |> ignore;
+
+/** Convert value from event to string
+One of the disadvantages from reason is that you have to do this type casting */
+let valueFromEvent = evt => (
+                              evt
+                              |> ReactEventRe.Form.target
+                              |> ReactDOMRe.domElementToObj
+                            )##value;

--- a/src/Services.re
+++ b/src/Services.re
@@ -16,7 +16,7 @@ module Decode = {
     };
 };
 
-let authenticate = (~email, ~password, ~success, ~failure, _self) => {
+let authenticate = (~email, ~password, ~callback, ~failure, _self) => {
   let authEndpoint = "https://jobhub-authentication-staging.herokuapp.com/login";
 
   let payload = Js.Dict.empty();
@@ -41,11 +41,12 @@ let authenticate = (~email, ~password, ~success, ~failure, _self) => {
     |> then_(json =>
       json
       |> Decode.authResponse
-      |> resp => success(resp.token)
+      |> resp => callback(Js.Option.some(resp.token))
       |> resolve
     )
     |> catch(err => {
       Js.log(err);
+      callback(None);
       failure();
       resolve();
     })

--- a/src/Utilities.re
+++ b/src/Utilities.re
@@ -1,0 +1,7 @@
+/** Convert value from event to string
+One of the disadvantages from reason is that you have to do this type casting */
+let valueFromEvent = evt => (
+                              evt
+                              |> ReactEventRe.Form.target
+                              |> ReactDOMRe.domElementToObj
+                            )##value;


### PR DESCRIPTION
### Description
 - Advances #10 by implementing error handling of the login form
 - Login is now a reducer component. 
   It performs the authentication and via a callback returns the JWT to the App component.
 - Services has a side-effect method "authenticate" which POSTs the credentials to the Auth backend.
   If the login is succesful, it returns the JWT to Login.
   If the login fails, it changes the state of Login to DisplayError
 - Services has a new type "authResponse" to decode the HTTP response
 - valueFromEvent was refactored to Services because its used in multiple components
 - Changed the `Sign in with Google` dummy button for `Sign Up`,
   which redirects the user to the web-app sign up page 
   (when it will be available online)

Closes #16

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] There is an open issue linked to this PR
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation (if necessary)
